### PR TITLE
Support to Use macbooks MPS device for Vision-Language CLIP Finetuning

### DIFF
--- a/engine/config/__init__.py
+++ b/engine/config/__init__.py
@@ -8,6 +8,13 @@ parser = argparse.ArgumentParser()
 # Directory Config (modify if using your own paths)
 ###########################
 parser.add_argument(
+    "--device", 
+    type=str, 
+    choices=["cpu", "cuda", "mps"], 
+    default="mps", 
+    help="Device to use (default: mps)")
+
+parser.add_argument(
     "--data_dir",
     type=str,
     default=default.DATA_DIR,

--- a/engine/config/__init__.py
+++ b/engine/config/__init__.py
@@ -11,7 +11,7 @@ parser.add_argument(
     "--device", 
     type=str, 
     choices=["cpu", "cuda", "mps"], 
-    default="mps", 
+    default="cuda", 
     help="Device to use (default: mps)")
 
 parser.add_argument(

--- a/engine/config/__init__.py
+++ b/engine/config/__init__.py
@@ -12,7 +12,7 @@ parser.add_argument(
     type=str, 
     choices=["cpu", "cuda", "mps"], 
     default="cuda", 
-    help="Device to use (default: mps)")
+    help="Device to use (default: cuda)")
 
 parser.add_argument(
     "--data_dir",

--- a/engine/model/head.py
+++ b/engine/model/head.py
@@ -80,7 +80,8 @@ def make_classifier_head(classifier_head,
                          classifier_init,
                          zeroshot_dataset,
                          text_encoder,
-                         bias=False):
+                         bias=False,
+                         device="cuda"):
     assert classifier_head in AVAI_HEADS
     if clip_encoder == 'ViT-B/16':
         in_features = 512
@@ -93,7 +94,7 @@ def make_classifier_head(classifier_head,
     if classifier_init == 'zeroshot':
         # assert zeroshot_dataset.input_tensor.shape[1] == in_features
         linear_head.weight.data = get_zero_shot_weights(
-            zeroshot_dataset, num_classes, in_features, text_encoder)
+            zeroshot_dataset, num_classes, in_features, text_encoder, device=device)
     
     if classifier_head == 'linear':
         head = linear_head

--- a/engine/model/logit.py
+++ b/engine/model/logit.py
@@ -4,13 +4,13 @@ import torch.nn.functional as F
 import numpy as np
 
 class LogitHead(nn.Module):
-    def __init__(self, head, logit_scale=float(np.log(1 / 0.07))):
+    def __init__(self, head, logit_scale=float(np.log(1 / 0.07)), device="cuda"):
         super().__init__()
         self.head = head
         self.logit_scale = logit_scale
         
         # Not learnable for simplicity
-        self.logit_scale = torch.FloatTensor([logit_scale]).cuda()
+        self.logit_scale = torch.FloatTensor([logit_scale]).to(device)
         # Learnable
         # self.logit_scale = torch.nn.Parameter(torch.ones([]) * logit_scale)
 

--- a/engine/tools/utils.py
+++ b/engine/tools/utils.py
@@ -14,6 +14,7 @@ def set_random_seed(seed):
     random.seed(seed)
     np.random.seed(seed)
     torch.manual_seed(seed)
+    torch.mps.manual_seed(seed)
     torch.cuda.manual_seed_all(seed)
 
 

--- a/engine/tools/utils.py
+++ b/engine/tools/utils.py
@@ -14,7 +14,11 @@ def set_random_seed(seed):
     random.seed(seed)
     np.random.seed(seed)
     torch.manual_seed(seed)
-    torch.mps.manual_seed(seed)
+    try:
+        torch.mps.manual_seed(seed)
+    except AttributeError:
+        # For non-mps devices, handling `AttributeError: module 'torch' has no attribute 'mps'`
+        pass
     torch.cuda.manual_seed_all(seed)
 
 

--- a/features.py
+++ b/features.py
@@ -236,7 +236,7 @@ def get_image_encoder(clip_model, args):
     return image_encoder
 
 
-def prepare_few_shot_image_features(clip_model, args, benchmark_train, benchmark_val, device="device"):
+def prepare_few_shot_image_features(clip_model, args, benchmark_train, benchmark_val, device):
     image_encoder = get_image_encoder(clip_model, args)
     # Check if (image) features are saved already
     image_features_path = get_image_features_path(

--- a/features.py
+++ b/features.py
@@ -166,7 +166,7 @@ def extract_features(image_encoder, data_source, transform, num_views=1, test_ba
     return features_dict
 
 
-def prepare_text_features(clip_model, args, lab2cname,device="cuda"):
+def prepare_text_features(clip_model, args, lab2cname, device="cuda"):
     text_encoder_dir = get_text_encoder_dir(
         args.feature_dir,
         args.clip_encoder,

--- a/features.py
+++ b/features.py
@@ -277,12 +277,13 @@ def prepare_few_shot_image_features(clip_model, args, benchmark_train, benchmark
         print(f"Extracting features for val split ...")
         image_features['val'] = extract_features(
             image_encoder, benchmark_val,
-            test_transform, num_views=1, test_batch_size=args.test_batch_size, num_workers=args.num_workers)
+            test_transform, num_views=1, test_batch_size=args.test_batch_size, num_workers=args.num_workers,
+            device=device)
     
         torch.save(image_features, image_features_path)
 
 
-def prepare_test_image_features(clip_model, args, benchmark_test):
+def prepare_test_image_features(clip_model, args, benchmark_test, device="cuda"):
     image_encoder = get_image_encoder(clip_model, args)
     # Check if features are saved already
     test_features_path = get_test_features_path(
@@ -302,7 +303,7 @@ def prepare_test_image_features(clip_model, args, benchmark_test):
         test_features = extract_features(
             image_encoder, 
             benchmark_test, test_transform,
-            num_views=1, test_batch_size=args.test_batch_size, num_workers=args.num_workers)
+            num_views=1, test_batch_size=args.test_batch_size, num_workers=args.num_workers, device=device)
         torch.save(test_features, test_features_path)
 
 
@@ -351,7 +352,7 @@ def main(args):
 
     prepare_few_shot_image_features(clip_model, args, few_shot_benchmark['train'], few_shot_benchmark['val'], device=device)
 
-    prepare_test_image_features(clip_model, args, few_shot_benchmark['test'])
+    prepare_test_image_features(clip_model, args, few_shot_benchmark['test'], device=device)
 
 
 if __name__ == "__main__":

--- a/features.sh
+++ b/features.sh
@@ -42,17 +42,17 @@ TOTAL=$(( TOTAL * ${#IMAGE_VIEWS[@]} ))
 
 
 declare -a DATASETS=(
-                     "imagenet"
+                    #  "imagenet"
                      "caltech101"
-                     "dtd"
-                     "eurosat"
-                     "fgvc_aircraft"
-                     "food101"
+                    #  "dtd"
+                    #  "eurosat"
+                    #  "fgvc_aircraft"
+                    #  "food101"
                      "oxford_flowers"
                      "oxford_pets"
-                     "stanford_cars"
-                     "sun397"
-                     "ucf101"
+                    #  "stanford_cars"
+                    #  "sun397"
+                    #  "ucf101"
                      )
 TOTAL=$(( TOTAL * ${#DATASETS[@]} ))
 

--- a/features.sh
+++ b/features.sh
@@ -42,17 +42,17 @@ TOTAL=$(( TOTAL * ${#IMAGE_VIEWS[@]} ))
 
 
 declare -a DATASETS=(
-                    #  "imagenet"
+                     "imagenet"
                      "caltech101"
-                    #  "dtd"
-                    #  "eurosat"
-                    #  "fgvc_aircraft"
-                    #  "food101"
+                     "dtd"
+                     "eurosat"
+                     "fgvc_aircraft"
+                     "food101"
                      "oxford_flowers"
                      "oxford_pets"
-                    #  "stanford_cars"
-                    #  "sun397"
-                    #  "ucf101"
+                     "stanford_cars"
+                     "sun397"
+                     "ucf101"
                      )
 TOTAL=$(( TOTAL * ${#DATASETS[@]} ))
 


### PR DESCRIPTION

By default, `cuda`  device is used. Using `--device mps` flag, we can run results on macbooks.


```(python)
parser.add_argument(
    "--device", 
    type=str, 
    choices=["cpu", "cuda", "mps"], 
    default="mps", 
    help="Device to use (default: mps)")
```

### Example Run for  `dtd` dataset 
1. Prepare Features with "none" and "flip" augmentations
```
python features.py --dataset dtd --train-shot 16 --seed 1 --clip-encoder RN50 --image-layer-idx 0 --text-augmentation hand_crafted --image-augmentation flip --image-views 1 --device mps

python features.py --dataset dtd --train-shot 16 --seed 1 --clip-encoder RN50 --image-layer-idx 0 --text-augmentation hand_crafted --image-augmentation flip --image-views 1 --device mps
```

2. Unimodal Training : 
```
python train.py --modality uni_modal --classifier_head linear --classifier_init random --logit 4.60517 --hyperparams linear --dataset dtd --train-shot 16 --seed 1 --clip-encoder RN50 --image-layer-idx 0 --text-augmentation hand_crafted --image-augmentation flip --image-views 1 --device mps
```

3. Crossmodal Training : 
```
python train.py --modality cross_modal --classifier_head linear --classifier_init random --logit 4.60517 --hyperparams linear --dataset dtd --train-shot 16 --seed 1 --clip-encoder RN50 --image-layer-idx 0 --text-augmentation hand_crafted --image-augmentation flip --image-views 1 --device mps
```


### Devices Tested : 
MPS Machine :   `macOS m3 pro, arm64`
Cuda Machine : `Rocky Linux release 8.6 , x86_64`
